### PR TITLE
owner propagator

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ class PointExtensions {
 
     public static Point add(
         PointSource self,
-        @DelegatesTo(value = PointSource.class, strategy = Closure.DELEGATE_FIRST)
-        @ClosureParams(value = SimpleType.class, options = "com.example.PointSource")
+        @DelegatesTo(value = PointBuilder.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "com.example.PointBuilder")
         Closure builder
     ) {
         return self.add(ConsumerWithDelegate.create(builder));
@@ -80,6 +80,39 @@ class PointExtensions {
 
 }
 ``` 
+
+Sometimes you need to change the owner for the closures. In that case you may want to implement `OwnerPropagator` interface
+which will help to carry over the original owner of the top most closure.
+
+```java
+class PointBuilderOwnerPropagator implements OwnerPropagator, PointBuilder {
+    private final PointBuilder builder;
+    private final Object owner;
+    
+    public PointBuilderOwnerPropagator(PointBuilder delegate, Object owner) {
+        this.builder = delegate;
+        this.owner = owner;
+    }
+    
+    @Override Object getOwner() { return owner; }
+    @Override PointBuilder x(int x) { return builder.x(x); }
+    @Override PointBuilder y(int y) { return builder.y(y); }
+    
+}
+
+class PointExtensions {
+
+    public static Point add(
+        PointSource self,
+        @DelegatesTo(value = PointBuilder.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "com.example.PointBuilder")
+        Closure builder
+    ) {
+        return self.add(ConsumerWithDelegate.create(builder, new PointBuilderOwnerPropagator(self, builder.getOwner())));
+    }
+
+}
+```
 
 ## Setup
 
@@ -93,7 +126,7 @@ repositories {
 }
 
 dependencies {
-    compile 'space.jasan:groovy-closure-support:0.3.0'
+    compile 'space.jasan:groovy-closure-support:0.3.1'
 }
 ```
 
@@ -137,7 +170,7 @@ dependencies {
 <dependency>
   <groupId>space.jasan</groupId>
   <artifactId>groovy-closure-support</artifactId>
-  <version>0.3.0</version>
+  <version>0.3.1</version>
   <type>pom</type>
 </dependency>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 
-version = '0.3.0'
+version = '0.3.1'
 
 apply plugin: 'groovy'
 apply plugin: 'checkstyle'

--- a/src/main/java/space/jasan/support/groovy/closure/ConsumerWithDelegate.java
+++ b/src/main/java/space/jasan/support/groovy/closure/ConsumerWithDelegate.java
@@ -15,7 +15,7 @@ public class ConsumerWithDelegate<T> implements Consumer<T> {
     }
 
     public static <T> Consumer<T> create(Closure c, int strategy) {
-        return create(c, c.getOwner(), strategy);
+        return create(c, OwnerPropagator.getPropagatedOwner(c.getOwner()), strategy);
     }
 
     public static <T> Consumer<T> create(Closure c) {

--- a/src/main/java/space/jasan/support/groovy/closure/ConsumerWithDelegate.java
+++ b/src/main/java/space/jasan/support/groovy/closure/ConsumerWithDelegate.java
@@ -15,7 +15,7 @@ public class ConsumerWithDelegate<T> implements Consumer<T> {
     }
 
     public static <T> Consumer<T> create(Closure c, int strategy) {
-        return create(c, OwnerPropagator.getPropagatedOwner(c.getOwner()), strategy);
+        return create(c, c.getOwner(), strategy);
     }
 
     public static <T> Consumer<T> create(Closure c) {
@@ -28,7 +28,7 @@ public class ConsumerWithDelegate<T> implements Consumer<T> {
 
     private ConsumerWithDelegate(Closure closure, int strategy, Object owner) {
         this.strategy = strategy;
-        this.owner = owner;
+        this.owner = OwnerPropagator.getPropagatedOwner(owner);
         this.closure = closure;
     }
 

--- a/src/main/java/space/jasan/support/groovy/closure/FunctionWithDelegate.java
+++ b/src/main/java/space/jasan/support/groovy/closure/FunctionWithDelegate.java
@@ -15,7 +15,7 @@ public class FunctionWithDelegate<T, R> implements Function<T, R> {
     }
 
     public static <T, R> Function<T, R> create(Closure<R> c, int strategy) {
-        return create(c, c.getOwner(), strategy);
+        return create(c, OwnerPropagator.getPropagatedOwner(c.getOwner()), strategy);
     }
 
     public static <T, R> Function<T, R> create(Closure<R> c) {

--- a/src/main/java/space/jasan/support/groovy/closure/FunctionWithDelegate.java
+++ b/src/main/java/space/jasan/support/groovy/closure/FunctionWithDelegate.java
@@ -15,7 +15,7 @@ public class FunctionWithDelegate<T, R> implements Function<T, R> {
     }
 
     public static <T, R> Function<T, R> create(Closure<R> c, int strategy) {
-        return create(c, OwnerPropagator.getPropagatedOwner(c.getOwner()), strategy);
+        return create(c, c.getOwner(), strategy);
     }
 
     public static <T, R> Function<T, R> create(Closure<R> c) {
@@ -28,7 +28,7 @@ public class FunctionWithDelegate<T, R> implements Function<T, R> {
 
     private FunctionWithDelegate(Closure<R> closure, int strategy, Object owner) {
         this.strategy = strategy;
-        this.owner = owner;
+        this.owner = OwnerPropagator.getPropagatedOwner(owner);
         this.closure = closure;
     }
 

--- a/src/main/java/space/jasan/support/groovy/closure/OwnerPropagator.java
+++ b/src/main/java/space/jasan/support/groovy/closure/OwnerPropagator.java
@@ -1,0 +1,13 @@
+package space.jasan.support.groovy.closure;
+
+public interface OwnerPropagator {
+
+    static Object getPropagatedOwner(Object object) {
+        if (object instanceof OwnerPropagator) {
+            return ((OwnerPropagator) object).getOwner();
+        }
+        return object;
+    }
+
+    Object getOwner();
+}

--- a/src/test/groovy/space/jasan/support/groovy/closure/ConsumerWithDelegateSpec.groovy
+++ b/src/test/groovy/space/jasan/support/groovy/closure/ConsumerWithDelegateSpec.groovy
@@ -19,11 +19,25 @@ class ConsumerWithDelegateSpec extends Specification {
             AcceptsConsumer.testMe(consumer).foo == 'FOO'
     }
 
+    void 'owner is set from propagator'() {
+        when:
+            Object o = null
+            ConsumerWithDelegate.create({
+                o = foo
+            }, new ConsumerWithDifferentOwner()).accept 'foobar'
+        then:
+            o == 'foo'
+    }
+
 }
 
 class ConsumerFoo {
     String foo = 'foo'
     String bar = 'bar'
+}
+
+class ConsumerWithDifferentOwner implements OwnerPropagator {
+    final Object owner = new ConsumerFoo()
 }
 
 class AcceptsConsumer {

--- a/src/test/groovy/space/jasan/support/groovy/closure/FunctionWithDelegateSpec.groovy
+++ b/src/test/groovy/space/jasan/support/groovy/closure/FunctionWithDelegateSpec.groovy
@@ -19,11 +19,25 @@ class FunctionWithDelegateSpec extends Specification {
             AcceptsFunction.testMe(closureFunction).foo == 'bar'
     }
 
+    void 'owner is set from propagator'() {
+        when:
+            Object o = null
+            FunctionWithDelegate.create({
+                o = foo
+            }, new FunctionWithDifferentOwner()).apply 'foobar'
+        then:
+            o == 'foo'
+    }
+
 }
 
 class FunctionFoo {
     String foo = 'foo'
     String bar = 'bar'
+}
+
+class FunctionWithDifferentOwner implements OwnerPropagator {
+    final Object owner = new FunctionFoo()
 }
 
 class AcceptsFunction {


### PR DESCRIPTION
new interface `OwnerPropagator` helps in the situations where you need to change the owner of the closure from the Java code.